### PR TITLE
app->debug and app->warning changed to app->log("{debug|warning}", ...)

### DIFF
--- a/lib/Dancer2/Plugin/Email.pm
+++ b/lib/Dancer2/Plugin/Email.pm
@@ -48,7 +48,7 @@ register email => sub {
             if (ref($attachment) eq 'HASH') {
                 %mime = %$attachment;
                 unless ($mime{Path}) {
-                    $dsl->app->warning("No Path provided for this attachment!");
+                    $dsl->app->log('warning', "No Path provided for this attachment!");
                     next;
                 };
                 $mime{Encoding} ||= 'base64';
@@ -76,7 +76,7 @@ register email => sub {
         if ($transport_redirect) {
             $transport_class = 'Email::Sender::Transport::Redirect';
             load $transport_class;
-            $dsl->app->debug("Redirecting email to $transport_redirect.");
+            $dsl->app->log('debug', "Redirecting email to $transport_redirect.");
             $transport = $transport_class->new(
                 transport        => $transport,
                 redirect_address => $transport_redirect


### PR DESCRIPTION
I should have caught this in an earlier PR but only noticed this today when using plugin for real with latest Dancer2 DEV release.

This commit is needed for next D2 release.
