### PR TITLE
Convert to pure plugin2 so it can be consumed by other plugins.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -34,6 +34,7 @@ repository.type   = git
 
 [Prereqs]
 Authen::SASL   = 2.16
+Dancer2        = 0.200000
 Net::SMTP::SSL = 1.01
 Net::SSLeay    = 1.58
 MIME::Base64   = 3.14


### PR DESCRIPTION
Converting to pure plugin2 allows this plugin to be consumed by other plugins and I'd really like to use this plugin inside Dancer2::Plugin::Auth::Extensible so I can throw out the existing email mess that's in there.
